### PR TITLE
Upgrade rclone and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ LABEL org.opencontainers.image.description="rclone - rsync for cloud storage"
 
 RUN apk --update --no-cache add \
         ca-certificates \
+        coreutils \
         inotify-tools \
         lz4 zstd
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.10 as base
+FROM alpine:3.11.3 as base
+
+## build-stage
 
 FROM base as builder
-ARG VERSION=v1.49.1
+ARG VERSION=v1.50.2
 
 RUN wget https://github.com/ncw/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip
@@ -10,9 +12,25 @@ RUN cd rclone-*-linux-amd64 && \
     chown root:root /usr/bin/rclone && \
     chmod 755 /usr/bin/rclone
 
+##
+## runtime-stage
+
 FROM base
 
-RUN apk --update --no-cache add ca-certificates inotify-tools lz4 zstd
+ARG VERSION=v1.50.2
+
+## https://github.com/opencontainers/image-spec/releases/tag/v1.0.1
+LABEL org.opencontainers.image.url="https://github.com/travelping/docker-rclone"
+LABEL org.opencontainers.image.source="https://github.com/travelping/docker-rclone"
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.vendor="Travelping GmbH"
+LABEL org.opencontainers.image.title="rclone-$VERSION"
+LABEL org.opencontainers.image.description="rclone - rsync for cloud storage"
+
+RUN apk --update --no-cache add \
+        ca-certificates \
+        inotify-tools \
+        lz4 zstd
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]


### PR DESCRIPTION
This PR bumps the packaged rclone version to v1.50.2. The changelog
for this release is available (here)[1]. The major changes (to
rclone-1.49.1) are addressing several memory leaks and more robustness.

Also part of this PR: 'coreutils' and a proper 'date' implementation are now part of the image. This allows to use ISO8601 formatted dates.

This PR also bumps the base image version to Alpine-3.11.3.

In addition, the Dockerfile now uses opencontainers.org labels to
annotate the created container image.

[1]: https://github.com/rclone/rclone/blob/master/docs/content/changelog.md#v1502---2019-11-19