### PR TITLE
Upgrade rclone to 1.65.1 and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.17 as base
+FROM alpine:3.19 as base
 
 ## build-stage
 
 FROM base as builder
-ARG VERSION=v1.60.1
+ARG VERSION=v1.65.1
 
 RUN wget https://github.com/rclone/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip
@@ -17,7 +17,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-ARG VERSION=v1.60.1
+ARG VERSION=v1.65.0
 
 ## https://github.com/opencontainers/image-spec/releases/tag/v1.0.1
 LABEL org.opencontainers.image.url="https://github.com/travelping/docker-rclone"


### PR DESCRIPTION
This commit bumps the packaged rclone version to v1.65.0. The changelog is available [here](https://rclone.org/changelog/#v1-60-1-2022-11-17).

Various bugfixes aside: Optimization on directory handling might address
empty directory memory consumption: https://github.com/rclone/rclone/pull/6561

Also: upgrade the base image to Alpine:3.19.0.