### PR TITLE
Upgrade rclone and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.19 as base
+FROM alpine:3.21.3 as base
 
 ## build-stage
 
 FROM base as builder
-ARG VERSION=v1.65.1
+ARG VERSION=v1.69.1
 
 RUN wget https://github.com/rclone/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
 RUN unzip rclone-$VERSION-linux-amd64.zip
@@ -17,7 +17,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-ARG VERSION=v1.65.0
+ARG VERSION=v1.69.1
 
 ## https://github.com/opencontainers/image-spec/releases/tag/v1.0.1
 LABEL org.opencontainers.image.url="https://github.com/travelping/docker-rclone"
@@ -28,10 +28,10 @@ LABEL org.opencontainers.image.title="rclone-$VERSION"
 LABEL org.opencontainers.image.description="rclone - rsync for cloud storage"
 
 RUN apk update && apk upgrade --no-cache && apk --no-cache add \
-        ca-certificates \
-        coreutils \
-        inotify-tools \
-        lz4 zstd
+    ca-certificates \
+    coreutils \
+    inotify-tools \
+    lz4 zstd
 COPY --from=builder /usr/bin/rclone /usr/bin/rclone
 
 ENTRYPOINT ["/usr/bin/rclone"]


### PR DESCRIPTION
This commit bumps the packaged rclone version to v1.69.1.

The changelog
for this release is available (here)[1](https://rclone.org/changelog/#v1-65-1-2024-01-08).

This PR also bumps the base image version to Alpine-3.21.3.