### PR TITLE
Chore: address CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.21.3 as base
+FROM alpine:3.23.3 as base
 
 ## build-stage
 
 FROM base as builder
-ARG VERSION=v1.69.1
+ARG VERSION=v1.73.1
+ARG SHA256=e9bad0be2ed85128e0d977bf36c165dd474a705ea950d18e1005cef98119407b
 
-RUN wget https://github.com/rclone/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip
-RUN unzip rclone-$VERSION-linux-amd64.zip
-RUN cd rclone-*-linux-amd64 && \
-    cp rclone /usr/bin/ && \
+ADD --checksum="sha256:$SHA256" https://github.com/rclone/rclone/releases/download/$VERSION/rclone-$VERSION-linux-amd64.zip /tmp/rclone.zip
+WORKDIR /tmp
+RUN unzip -d . rclone.zip "**/rclone" && \
+    find . -name "rclone" -type f -exec cp {} /usr/bin ';' && \
     chown root:root /usr/bin/rclone && \
     chmod 755 /usr/bin/rclone
 
@@ -17,7 +18,7 @@ RUN cd rclone-*-linux-amd64 && \
 
 FROM base
 
-ARG VERSION=v1.69.1
+ARG VERSION=v1.73.1
 
 ## https://github.com/opencontainers/image-spec/releases/tag/v1.0.1
 LABEL org.opencontainers.image.url="https://github.com/travelping/docker-rclone"


### PR DESCRIPTION
Upgrade rclone to 1.73.1, base image to Alpine:3.23.3

This PR bumps the packaged rclone version to v1.73.1, the detailed
changelog is available [here](https://rclone.org/changelog/#v1-73-1-2026-02-17).

In addition, upgrade the base image to Alpine:3.23.3.

As a result, all these CVEs in image docker-rclone:v1.69.1-sec.2 are fixed:

    busybox@1.35.0-r29          CVE-2023-42363  MEDIUM
    busybox@1.35.0-r29          CVE-2023-42364  MEDIUM
    busybox@1.35.0-r29          CVE-2023-42365  MEDIUM
    busybox@1.35.0-r29          CVE-2023-42366  MEDIUM
    busybox-binsh@1.35.0-r29    CVE-2023-42363  MEDIUM
    busybox-binsh@1.35.0-r29    CVE-2023-42364  MEDIUM
    busybox-binsh@1.35.0-r29    CVE-2023-42365  MEDIUM
    busybox-binsh@1.35.0-r29    CVE-2023-42366  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2025-15467  CRITICAL
    libcrypto3@3.0.8-r4         CVE-2023-5363   HIGH
    libcrypto3@3.0.8-r4         CVE-2024-6119   HIGH
    libcrypto3@3.0.8-r4         CVE-2025-69419  HIGH
    libcrypto3@3.0.8-r4         CVE-2025-69421  HIGH
    libcrypto3@3.0.8-r4         CVE-2023-2650   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-2975   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-3446   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-3817   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-5678   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-6129   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2023-6237   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-0727   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-13176  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-4603   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-4741   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-5535   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2025-68160  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2025-69418  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2025-69420  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2025-9230   MEDIUM
    libcrypto3@3.0.8-r4         CVE-2026-22795  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2026-22796  MEDIUM
    libcrypto3@3.0.8-r4         CVE-2024-2511   LOW
    libcrypto3@3.0.8-r4         CVE-2024-9143   LOW
    libcrypto3@3.0.8-r4         CVE-2025-9232   LOW
    libssl3@3.0.8-r4            CVE-2025-15467  CRITICAL
    libssl3@3.0.8-r4            CVE-2023-5363   HIGH
    libssl3@3.0.8-r4            CVE-2024-6119   HIGH
    libssl3@3.0.8-r4            CVE-2025-69419  HIGH
    libssl3@3.0.8-r4            CVE-2025-69421  HIGH
    libssl3@3.0.8-r4            CVE-2023-2650   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-2975   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-3446   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-3817   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-5678   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-6129   MEDIUM
    libssl3@3.0.8-r4            CVE-2023-6237   MEDIUM
    libssl3@3.0.8-r4            CVE-2024-0727   MEDIUM
    libssl3@3.0.8-r4            CVE-2024-13176  MEDIUM
    libssl3@3.0.8-r4            CVE-2024-4603   MEDIUM
    libssl3@3.0.8-r4            CVE-2024-4741   MEDIUM
    libssl3@3.0.8-r4            CVE-2024-5535   MEDIUM
    libssl3@3.0.8-r4            CVE-2025-68160  MEDIUM
    libssl3@3.0.8-r4            CVE-2025-69418  MEDIUM
    libssl3@3.0.8-r4            CVE-2025-69420  MEDIUM
    libssl3@3.0.8-r4            CVE-2025-9230   MEDIUM
    libssl3@3.0.8-r4            CVE-2026-22795  MEDIUM
    libssl3@3.0.8-r4            CVE-2026-22796  MEDIUM
    libssl3@3.0.8-r4            CVE-2024-2511   LOW
    libssl3@3.0.8-r4            CVE-2024-9143   LOW
    libssl3@3.0.8-r4            CVE-2025-9232   LOW
    musl@1.2.3-r4               CVE-2025-26519  HIGH
    musl-utils@1.2.3-r4         CVE-2025-26519  HIGH
    ssl_client@1.35.0-r29       CVE-2023-42363  MEDIUM
    ssl_client@1.35.0-r29       CVE-2023-42364  MEDIUM
    ssl_client@1.35.0-r29       CVE-2023-42365  MEDIUM
    ssl_client@1.35.0-r29       CVE-2023-42366  MEDIUM